### PR TITLE
Fix pulsesigmoid duration

### DIFF
--- a/src/timeseries.cpp
+++ b/src/timeseries.cpp
@@ -259,13 +259,25 @@ namespace TIMESERIES {
     }
     configf.optional("Pulses", pulses);
     configf.optional("Sigma", sigma);
-    pulse_count = min(pulses, duration/period);
+    if( (duration != inf) && (period != inf) ) {
+      pulse_count = min(pulses, duration/period);
+    } else {
+      pulse_count = pulses;
+    }
+
+    if( (pulse_count > 1) && (period == inf) ) {
+      cerr << "ERROR: Multiple PulseSigmoid pulses requested but no Period or Frequency specified."
+           << endl;
+      exit(EXIT_FAILURE);
+    }
 
     first_pulse_mid = onset + (width / 2.0);
 
-    onset_midpoints.assign(pulse_count, 0.0);
-    for( size_type i=0; i<pulse_count; i++ ) {
-      onset_midpoints[i] = onset + (i * period);
+    onset_midpoints.assign(pulse_count, onset);
+    if( pulse_count > 1 ) {
+      for( size_type i=1; i<pulse_count; ++i ) {
+        onset_midpoints[i] = onset + (i * period);
+      }
     }
 
     // As we need to begin evaluation before onset for this Timeseries, as
@@ -273,7 +285,9 @@ namespace TIMESERIES {
     // we reset the time-series' internal time to zero and adjust the duration
     // accordingly.
     t = 0.0;
-    duration = duration + onset;
+    if( duration != inf ) {
+      duration = duration + onset;
+    }
   }
 
   /** @brief Generate a train of sigmoidal pulses.*/

--- a/src/timeseries.cpp
+++ b/src/timeseries.cpp
@@ -248,7 +248,6 @@ namespace TIMESERIES {
     // Set default values for optional parameters.
     period = inf; // Time between the start of each pulse [s].
     pulses = 1.0; // Maximum number of pulses.
-    sigma = 0.03125; // Width of transition.
     configf.param("Amplitude", amp);
     configf.param("Width", width);
     if( !configf.optional("Period", period) ) {
@@ -257,8 +256,16 @@ namespace TIMESERIES {
         period = 1.0 / freq;
       }
     }
+
     configf.optional("Pulses", pulses);
-    configf.optional("Sigma", sigma);
+
+    if (!configf.optional("Sigma", sigma)){
+      // Set an adaptive default width of transition. A sigmoidal-pulse
+      // waveform is achieved when sigma is a small fraction of width.
+      // However, to be represented properly it must be at least deltat.
+      sigma = max(width / 16.0, deltat);
+    }
+
     if( (duration != inf) && (period != inf) ) {
       pulse_count = min(pulses, duration/period);
     } else {


### PR DESCRIPTION
Fixes issue #162

  + Now correctly handles unspecified duration and period.
  + Generates error message and aborts if multiple pulses are requested without Period or Frequency being specified.

Also adds a default sigma value that adapts to the specified width, such that `PulseSigmoid` defaults to the intended waveform. This resolves issue #156 .

All numerical tests return `SAME` -- currently, both `./test/numerical/e-cortical.conf` and `./test/numerical/e-cortical-legacy.conf` make use of `PulseSigmoid`.
