### PR TITLE
Check white noise

### DIFF
--- a/+nf/rfft.m
+++ b/+nf/rfft.m
@@ -8,12 +8,12 @@
 %        y  -- a 2D array of size (timepoints x N), where N is the number of signals/timeseries or traces.
 %        fs -- sampling frequency (Hz) of the time series.
 %        NFFT -- override the amount of zero padding in the FFT.
-%        windowed -- set as true to apply a Hamming window.
+%        windowed  -- set as true to apply a Hamming window.
 %        detrended -- set as true to remove any constant offset and linear trend.
 %
 % OUTPUT:
 %        f -- frequency values
-%        s -- Fourier components, denoted c_k in Chris Rennie's notes.
+%        Y -- Fourier components, denoted c_k in Chris Rennie's notes.
 %        P -- (fpts, N) Mean spectral power density, correct power is obtained by
 %             integrating w.r.t. frequency values (f).
 %
@@ -27,11 +27,11 @@
 % USAGE:
 %{
     %
-    [f, s, P] = nf.rfft(y, fs, NFFT)
+    [f, Y, P] = nf.rfft(y, fs, NFFT)
 %}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-function [f, Y, P, varargout] = rfft(y, fs, NFFT, windowed, detrended, one_sided)
+function [f, Y, P] = rfft(y, fs, NFFT, windowed, detrended, one_sided)
     %
     if nargin < 6
        one_sided = true;
@@ -89,6 +89,7 @@ function [f, Y, P, varargout] = rfft(y, fs, NFFT, windowed, detrended, one_sided
         end
             
     else
+        Y = fftshift(Y);
         f = -(fs/2)+freq_bin_width:freq_bin_width:(fs/2);
         P = abs(Y).^2; % two sided spectrum 
 

--- a/+nf/rfft.m
+++ b/+nf/rfft.m
@@ -1,12 +1,12 @@
 %% Fourier transform
 %
-% Heavily based on Chris Rennie's notes, see REFERERENCES below.
+% Heavily based on Chris Rennie's notes, see REFERENCES below.
 %
 % The normalization is such that sum(abs(y).^2)/length(y) = trapz(f,P)
 %
 % ARGUMENTS:
-%        y -- (tpts, N) time series.
-%        fs -- sampling frequency (Hz) for the time series.
+%        y  -- a 2D array of size (timepoints x N), where N is the number of signals/timeseries or traces.
+%        fs -- sampling frequency (Hz) of the time series.
 %        NFFT -- override the amount of zero padding in the FFT.
 %        windowed -- set as true to apply a Hamming window.
 %        detrended -- set as true to remove any constant offset and linear trend.

--- a/+nf/rfft.m
+++ b/+nf/rfft.m
@@ -90,7 +90,7 @@ function [f, Y, P] = rfft(y, fs, NFFT, windowed, detrended, one_sided)
             
     else
         Y = fftshift(Y);
-        f = -(fs/2)+freq_bin_width:freq_bin_width:(fs/2);
+        f = -(fs/2):freq_bin_width:(fs/2)-freq_bin_width;
         P = abs(Y).^2; % two sided spectrum 
 
     end

--- a/+nf/rfft.m
+++ b/+nf/rfft.m
@@ -65,7 +65,7 @@ function [f, Y, P] = rfft(y, fs, NFFT, windowed, detrended, one_sided)
         y = y .* window_func;
     end
     
-    Y = fft(y, NFFT) / size(y, 1); % Correctly normalized Fourier components c_k
+    Y = fft(y, NFFT) / NFFT;%size(y, 1); % Correctly normalized Fourier components c_k
     %s = ifft(y, NFFT); % Correctly normalized Fourier components c_k with positive exponent in the FFT
 
 

--- a/+nf/spectrum.m
+++ b/+nf/spectrum.m
@@ -1,5 +1,6 @@
-%% Return the frequency and frequency spectrum of given nftsim output.
-%
+%% Returns the frequency vector and frequency power spectrum of a given nftsim structure.
+%  By default this function returns the one-sided power spectrum from 0 to fs/2, where fs is the
+%  sampling frequency.
 % ARGUMENTS:
 %        obj -- A nftsim output struct (a Matlab struct containing data
 %               from a simulation).

--- a/benchmarks/eirs-default.conf
+++ b/benchmarks/eirs-default.conf
@@ -56,7 +56,7 @@ Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
 
 Population 5: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 1e-05
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 1e-05
 
 Propagator 1: Wave - Tau: 0 Range: 0.086 gamma: 116
 Propagator 2: Map - Tau: 0

--- a/benchmarks/eirs-nodes-1024.conf
+++ b/benchmarks/eirs-nodes-1024.conf
@@ -56,7 +56,7 @@ Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
 
 Population 5: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 1e-05
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 1e-05
 
 Propagator 1: Wave - Tau: 0 Range: 0.086 gamma: 116
 Propagator 2: Map - Tau: 0

--- a/benchmarks/eirs-time-150.conf
+++ b/benchmarks/eirs-time-150.conf
@@ -56,7 +56,7 @@ Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
 
 Population 5: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 1e-05
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 1e-05
 
 Propagator 1: Wave - Tau: 0 Range: 0.086 gamma: 116
 Propagator 2: Map - Tau: 0

--- a/benchmarks/eirs-traces-8.conf
+++ b/benchmarks/eirs-traces-8.conf
@@ -57,7 +57,7 @@ Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
 
 Population 5: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 1e-05
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 1e-05
 
 Propagator 1: Wave - Tau: 0 Range: 0.086 gamma: 116
 Propagator 2: Map - Tau: 0

--- a/benchmarks/eirs-wavepropagators-11.conf
+++ b/benchmarks/eirs-wavepropagators-11.conf
@@ -57,7 +57,7 @@ Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
 
 Population 5: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 1e-05
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 1e-05
 
 Propagator 1: Wave - Tau: 0 Range: 0.086 gamma: 116
 Propagator 2: Wave - Tau: 0 Range: 0.086 gamma: 116

--- a/configs/Plasticity/eirs-bcm.conf
+++ b/configs/Plasticity/eirs-bcm.conf
@@ -44,8 +44,8 @@ Length: 0.05
 Population 5: Stimulation
 Length: 0.5
  Stimulus: Superimpose: 2
-  Stimulus: White - Onset: 0 Mean: 1 PSD: 1e-5 
-  Stimulus: White - Onset: 2 Mean: .5 PSD: 1e-5 
+  Stimulus: White - Onset: 0 Mean: 1 ASD: 1e-5 
+  Stimulus: White - Onset: 2 Mean: .5 ASD: 1e-5 
 
 Propagator 1: Wave - Tau: 0 Range: 86e-3 gamma: 116
 Propagator 2:  Map - Tau: 0

--- a/configs/Plasticity/plasticity.conf
+++ b/configs/Plasticity/plasticity.conf
@@ -9,7 +9,7 @@ To 2: 1 2
 
 Population 1: Stimulation
  Length: 0.01
- Stimulus: White - Onset: 0 Node: 3 6 Mean: .1 PSD: 0
+ Stimulus: White - Onset: 0 Node: 3 6 Mean: .1 ASD: 0
 
 Population 2: Excitatory neurons
 Length: 0.01

--- a/configs/Published/Abeysuriya_2014/figure_1.conf
+++ b/configs/Published/Abeysuriya_2014/figure_1.conf
@@ -55,7 +55,7 @@ Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
 
 Population 5: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 0.0001
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 0.0001
 
 Propagator 1: Wave - Tau: 0 Range: 0.086 gamma: 116
 Propagator 2: Map - Tau: 0

--- a/configs/Published/Abeysuriya_2014/figure_1.conf
+++ b/configs/Published/Abeysuriya_2014/figure_1.conf
@@ -55,7 +55,7 @@ Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
 
 Population 5: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1 ASD: 0.0001
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 7.071067811865475e-05
 
 Propagator 1: Wave - Tau: 0 Range: 0.086 gamma: 116
 Propagator 2: Map - Tau: 0

--- a/configs/Published/Abeysuriya_2014/figure_2.conf
+++ b/configs/Published/Abeysuriya_2014/figure_2.conf
@@ -55,7 +55,7 @@ Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
 
 Population 5: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 0.0001
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 0.0001
 
 Propagator 1: Wave - Tau: 0 Range: 0.086 gamma: 116
 Propagator 2: Map - Tau: 0

--- a/configs/Published/Abeysuriya_2014/figure_2.conf
+++ b/configs/Published/Abeysuriya_2014/figure_2.conf
@@ -55,7 +55,7 @@ Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
 
 Population 5: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1 ASD: 0.0001
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 7.071067811865475e-05
 
 Propagator 1: Wave - Tau: 0 Range: 0.086 gamma: 116
 Propagator 2: Map - Tau: 0

--- a/configs/Published/Abeysuriya_2014/readme.txt
+++ b/configs/Published/Abeysuriya_2014/readme.txt
@@ -18,8 +18,8 @@ directory (in dispersion_calc.m). However, this code has not been prepared for
 general use yet and is essentially undocumented.
 
 The remaining figures in the paper use the same model parameters, with
-different noise powers. These can be set by changing the PSD quantity of the
+different noise amplitudes. These can be set by changing the ASD quantity of the
 stimulus in the configuration file to match the quantity in the paper. For
-example, Figure 2 is generated using mu = 1e-4, and figure_2.conf has "PSD:
-0.0001". To generate Figure 5, simply change PSD to each of the specified mu
+example, Figure 2 is generated using mu = 1e-4, and figure_2.conf has "ASD:
+0.0001". To generate Figure 5, simply change ASD to each of the specified mu
 values in the figure caption.

--- a/configs/Published/Abeysuriya_2014/readme.txt
+++ b/configs/Published/Abeysuriya_2014/readme.txt
@@ -20,6 +20,6 @@ general use yet and is essentially undocumented.
 The remaining figures in the paper use the same model parameters, with
 different noise amplitudes. These can be set by changing the ASD quantity of the
 stimulus in the configuration file to match the quantity in the paper. For
-example, Figure 2 is generated using mu = 1e-4, and figure_2.conf has "ASD:
-0.0001". To generate Figure 5, simply change ASD to each of the specified mu
-values in the figure caption.
+example, Figure 2 is generated using mu = 1e-4, so figure_2.conf sould have a value of ASD
+of 0.0001/sqrt(2). To generate Figure 5, simply change ASD to each of the specified mu
+values in the figure caption divided by sqrt(2).

--- a/configs/Published/van-Albada_2009/eirs-bg.conf
+++ b/configs/Published/van-Albada_2009/eirs-bg.conf
@@ -121,7 +121,7 @@ Firing: Function: Sigmoid Theta: 0.01 Sigma: 0.0033 Qmax: 500
 
 Population 10: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 1e-05
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 1e-05
 
 Propagator 1: Wave - Tau: 0 Range: 0.08 gamma: 125
 Propagator 2: Map - Tau: 0

--- a/configs/TMS/teps-bi.conf
+++ b/configs/TMS/teps-bi.conf
@@ -57,7 +57,7 @@ Population 5: Relay
 
 Population 6: Stimulation
  Length: .5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 0.0001
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 0.0001
 
 Population 7: TMS
  Length: .5

--- a/configs/TMS/teps-gabab.conf
+++ b/configs/TMS/teps-gabab.conf
@@ -58,7 +58,7 @@ Population 5: Relay
 
 Population 6: Stimulation
  Length: .5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 0.0001
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 0.0001
 
 Population 7: TMS
  Length: .5

--- a/configs/TMS/teps-mono.conf
+++ b/configs/TMS/teps-mono.conf
@@ -57,7 +57,7 @@ Population 5: Relay
 
 Population 6: Stimulation
  Length: .5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 0.0001
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 0.0001
 
 Population 7: TMS
  Length: .5

--- a/configs/eirs-burst.conf
+++ b/configs/eirs-burst.conf
@@ -44,7 +44,7 @@ Population 4: Relay
 
 Population 5: Stimulation
  Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 1e-05
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 1e-05
 
 Propagator 1:  Wave - Tau: 0     Range: 86e-3 gamma: 100
 Propagator 2:  Map  - Tau: 0

--- a/configs/eirs-corticothalamic.conf
+++ b/configs/eirs-corticothalamic.conf
@@ -56,7 +56,7 @@ Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
 
 Population 5: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 1e-05
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 1e-05
 
 Propagator 1: Wave - Tau: 0 Range: 0.086 gamma: 116
 Propagator 2: Map - Tau: 0

--- a/configs/eirs-coupling-diffarctan.conf
+++ b/configs/eirs-coupling-diffarctan.conf
@@ -56,7 +56,7 @@ Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
 
 Population 5: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 1e-05
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 1e-05
 
 Propagator 1: Wave - Tau: 0 Range: 0.086 gamma: 116
 Propagator 2: Map - Tau: 0

--- a/configs/eirs-coupling-ramp.conf
+++ b/configs/eirs-coupling-ramp.conf
@@ -64,7 +64,7 @@ Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
 
 Population 5: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 1e-05
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 1e-05
 
 Propagator 1: Wave - Tau: 0 Range: 0.086 gamma: 116
 Propagator 2: Map - Tau: 0

--- a/configs/eirs-dendrite-integral.conf
+++ b/configs/eirs-dendrite-integral.conf
@@ -56,7 +56,7 @@ Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
 
 Population 5: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1 PSD: 1e-05
+ Stimulus: White - Onset: 0 Mean: 1 ASD: 1e-05
 
 Propagator 1: Wave - Tau: 0 Range: 0.086 gamma: 116
 Propagator 2: Map - Tau: 0

--- a/configs/eirs-tms.conf
+++ b/configs/eirs-tms.conf
@@ -45,7 +45,7 @@ Population 4: Relay
 
 Population 5: Stimulation
  Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1.1 PSD: 1e-5 
+ Stimulus: White - Onset: 0 Mean: 1.1 ASD: 1e-5 
 
 Population 6: TMS
  Length: 0.5

--- a/configs/stimulus-test-white.conf
+++ b/configs/stimulus-test-white.conf
@@ -1,0 +1,17 @@
+Time: 64 Deltat: 9.765625e-04
+Nodes: 1
+
+    Connection matrix:
+From:  1 
+To 1:  0
+
+
+Population 1: Stimulation
+Length: 0.5
+    Stimulus: White - Onset: 0 Mean: 0 ASD: 1e-05
+
+Output: Node: All Start: 0
+Population: 1
+Dendrite:  
+Propagator:
+Coupling: 

--- a/configs/test_coupling_map.conf
+++ b/configs/test_coupling_map.conf
@@ -1,0 +1,26 @@
+Test configuration file for issue #101
+
+Time: 0.15 Deltat: 0.0001
+Nodes: 900
+
+    Connection matrix:
+From:  1  
+To 1:  1   
+
+
+Population 1: Excitatory
+Length: 0.5
+Q: 10
+Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
+ Dendrite 1: alpha: 83 beta: 769
+
+
+Propagator 1: Wave - Tau: 0 Range: 0.2 gamma: 30
+
+Coupling 1:  Map - nu: 1e-4
+
+Output: Node: 1 Start: 0 
+Population: 
+Dendrite: 
+Propagator: 1
+Coupling: 1  

--- a/configs/test_coupling_ramp.conf
+++ b/configs/test_coupling_ramp.conf
@@ -1,0 +1,26 @@
+Test configuration file for issue #101
+
+Time: 0.15 Deltat: 0.0001
+Nodes: 900
+
+    Connection matrix:
+From:  1  
+To 1:  1   
+
+
+Population 1: Excitatory
+Length: 0.5
+Q: 10
+Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
+ Dendrite 1: alpha: 83 beta: 769
+
+
+Propagator 1: Wave - Tau: 0 Range: 0.2 gamma: 30
+
+Coupling 1:  Ramp - nus: 1e-4 1e-4 timepoints: 0.05 0.1
+
+Output: Node: 1 Start: 0 
+Population: 
+Dendrite: 
+Propagator: 1
+Coupling: 1  

--- a/configs/test_time-validation.conf
+++ b/configs/test_time-validation.conf
@@ -1,0 +1,33 @@
+Example to test warning messages
+
+Time: 0.15625 Deltat: 1.220703125e-04
+Nodes: 4
+
+    Connection matrix:
+From:  1  2 
+To 1:  1  2  
+To 2:  0  0  
+
+
+Population 1: Excitatory
+Length: 0.05
+Q: 10
+Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340
+ Dendrite 1: alpha: 1 beta: 1
+ Dendrite 2: alpha: 1 beta: 1
+
+Population 2: Stimulation
+Length: 0.05
+ Stimulus: PulseRect - Onset: 0 Node: 1 Amplitude: 1 Width: 1e-3 
+
+Propagator 1: Wave - Tau: 1.220703125e-04 1.33 1.33 1.27 Range: 0.1 gamma: 200
+Propagator 2: Map - 
+
+Coupling 1:  Map - nu: 0
+Coupling 2:  Map - nu: 1e-4
+
+Output: Node: 1 Start: 0 Interval: 0.005
+Population: 
+Dendrite:
+Propagator: 1
+Coupling:   

--- a/doc/NFTsimManual.tex
+++ b/doc/NFTsimManual.tex
@@ -377,12 +377,12 @@ Sine - Amplitude: 1.0 Frequency: 2.0
 White - Mean: 1 StdDev: 20 Ranseed: 10
     \end{lstlisting}
 
-    Alternatively, the power spectral density (ASD) may be specified instead of the standard deviation (StdDev). The advantage is that the ASD is invariant to change in \type{Deltat}, population \type{Length} and spatial \type{Nodes}. Given the ASD, \NF correctly calculates the standard deviation:
+    Alternatively, the amplitude spectral density (ASD), which is the square root of the power spectral density (PSD) may be specified instead of the standard deviation (StdDev). The advantage of using ASD is that NFTsim will preserve the ASD under changes in \type{Deltat}, population \type{Length} and spatial \type{Nodes}. Given the ASD, \NF  calculates the standard deviation:
     \begin{lstlisting}
 White - Mean: 1 ASD: 20 Ranseed: 10
     \end{lstlisting}
 
-    In general, it is preferable to specify the noise using \texttt{ASD} rather than \texttt{StdDev}. 
+    In general, it is preferable to specify the noise amplitude using \texttt{ASD} rather than \texttt{StdDev}. Note that the ASD reported in paper is given assuming the power spectrum is calculated with respect to angular frequency $\omega$, instead of linear frequency $f$. ASD(f) is larger than ASD($\omega$) by a factor of $\pi$ or $2\pi$ whther one calculates the two-sided or one-sided spectrum, respectively.
 
     The random number generator may be specified in \type{Ranseed}. If a seed is not specified, an automatically-incremented seed will be used instead, so that multiple stimulus populations will have independent sequences. In general it is not necessary to set the seed manually unless different random numbers are required for otherwise identical runs.
 

--- a/doc/NFTsimManual.tex
+++ b/doc/NFTsimManual.tex
@@ -382,7 +382,7 @@ White - Mean: 1 StdDev: 20 Ranseed: 10
 White - Mean: 1 ASD: 20 Ranseed: 10
     \end{lstlisting}
 
-    In general, it is preferable to specify the noise amplitude using \texttt{ASD} rather than \texttt{StdDev}. Note that the ASD reported in paper is given assuming the power spectrum is calculated with respect to angular frequency $\omega$, instead of linear frequency $f$. ASD(f) is larger than ASD($\omega$) by a factor of $\pi$ or $2\pi$ whther one calculates the two-sided or one-sided spectrum, respectively.
+    In general, it is preferable to specify the noise amplitude using \texttt{ASD} rather than \texttt{StdDev}. Note that the ASD reported in paper is given assuming the power spectrum is calculated with respect to angular frequency $\omega$, instead of linear frequency $f$. ASD(f) is larger than ASD($\omega$) by a factor of $2\pi$ (e.f. ASD($f$)=$2\pi$*ASD(\omega)). 
 
     The random number generator may be specified in \type{Ranseed}. If a seed is not specified, an automatically-incremented seed will be used instead, so that multiple stimulus populations will have independent sequences. In general it is not necessary to set the seed manually unless different random numbers are required for otherwise identical runs.
 

--- a/doc/NFTsimManual.tex
+++ b/doc/NFTsimManual.tex
@@ -328,7 +328,7 @@ Population 1: Stimulation
     \begin{lstlisting}
 Length: .5
     \end{lstlisting}
-    The physical edge length of the population (which is a 2D sheet), in metres. This is used in \type{Wave} propagators and the \type{PSD} of \type{White} stimulus.
+    The physical edge length of the population (which is a 2D sheet), in metres. This is used in \type{Wave} propagators and the \type{ASD} of \type{White} stimulus.
     \item
     \begin{lstlisting}
 Stimulus: Const - Onset: 0
@@ -377,12 +377,12 @@ Sine - Amplitude: 1.0 Frequency: 2.0
 White - Mean: 1 StdDev: 20 Ranseed: 10
     \end{lstlisting}
 
-    Alternatively, the power spectral density (PSD) may be specified instead of the standard deviation (StdDev). The advantage is that the PSD is invariant to change in \type{Deltat}, population \type{Length} and spatial \type{Nodes}. Given the PSD, \NF correctly calculates the standard deviation:
+    Alternatively, the power spectral density (ASD) may be specified instead of the standard deviation (StdDev). The advantage is that the ASD is invariant to change in \type{Deltat}, population \type{Length} and spatial \type{Nodes}. Given the ASD, \NF correctly calculates the standard deviation:
     \begin{lstlisting}
-White - Mean: 1 PSD: 20 Ranseed: 10
+White - Mean: 1 ASD: 20 Ranseed: 10
     \end{lstlisting}
 
-    In general, it is preferable to specify the noise using \texttt{PSD} rather than \texttt{StdDev}. 
+    In general, it is preferable to specify the noise using \texttt{ASD} rather than \texttt{StdDev}. 
 
     The random number generator may be specified in \type{Ranseed}. If a seed is not specified, an automatically-incremented seed will be used instead, so that multiple stimulus populations will have independent sequences. In general it is not necessary to set the seed manually unless different random numbers are required for otherwise identical runs.
 
@@ -392,7 +392,7 @@ White - Mean: 1 PSD: 20 Ranseed: 10
     To superimpose 2 or more stimuli, begin with the keyword \type{Superimpose}, followed by the number of stimuli. Then list all the stimulus patterns and their parameters, with each stimulus pattern preceded by the keyword \type{Stimulus}.
     \begin{lstlisting}
 Stimulus: Superimpose: 2
- Stimulus: White - Mean: 1 PSD: 1
+ Stimulus: White - Mean: 1 ASD: 1
  Stimulus: PulseRect - Onset: 0.5 Width: 2e-2 Frequency 1 Pulses: 1
     \end{lstlisting}
 

--- a/src/timeseries.cpp
+++ b/src/timeseries.cpp
@@ -329,9 +329,9 @@ namespace TIMESERIES {
       if(nodes>1) {
         deltax = atof(configf.find(
                         label("Population ",index+1)+"*Length").c_str()) /sqrt(nodes);
-        stddev = sqrt(4.0*pow(M_PI,3)*pow(asd,2)/deltat/pow(deltax,2));
+        stddev = sqrt(2.0*4.0*pow(M_PI,3)*pow(asd,2)/deltat/pow(deltax,2));
       } else {
-        stddev = sqrt(M_PI*pow(asd,2)/deltat);
+        stddev = sqrt(2.0*M_PI*pow(asd,2)/deltat);
       }
 
     }

--- a/src/timeseries.cpp
+++ b/src/timeseries.cpp
@@ -319,18 +319,19 @@ namespace TIMESERIES {
   /** @brief Initialises white noise.*/
   void White::init( Configf& configf ) {
     // Mean: 1 StdDev: 1 Ranseed: 1
-    // Mean: 1 PSD: 1 Ranseed: 1
+    // Mean: 1 ASD: 1e-05 Ranseed: 1
+    // ASD stands for Amplitude Spectral Density, which is the square root of PSD (Power Spectral Density)
     configf.param("Mean", mean);
     if( !configf.optional("StdDev", stddev) ) {
-      configf.param("PSD", psd);
+      configf.param("ASD", asd);
       // index of timeseries the same as that of population
 
       if(nodes>1) {
         deltax = atof(configf.find(
                         label("Population ",index+1)+"*Length").c_str()) /sqrt(nodes);
-        stddev = sqrt(4.0*pow(M_PI,3)*pow(psd,2)/deltat/pow(deltax,2));
+        stddev = sqrt(4.0*pow(M_PI,3)*pow(asd,2)/deltat/pow(deltax,2));
       } else {
-        stddev = sqrt(M_PI*pow(psd,2)/deltat);
+        stddev = sqrt(M_PI*pow(asd,2)/deltat);
       }
 
     }
@@ -352,14 +353,14 @@ namespace TIMESERIES {
   /** @brief Initialises spatially uniform/coherent white noise.*/
   void WhiteCoherent::init( Configf& configf ) {
     // Mean: 1 StdDev: 1 Ranseed: 1
-    // Mean: 1 PSD: 1 Ranseed: 1
+    // Mean: 1 ASD: 1e-05 1 Ranseed: 1
     configf.param("Mean", mean);
     if( !configf.optional("StdDev", stddev) ) {
-      configf.param("PSD", psd);
+      configf.param("ASD", asd);
       // index of timeseries the same as that of population
       double deltax = atof(configf.find(
                              label("Population ",index+1)+"*Length").c_str()) /sqrt(nodes);
-      stddev = sqrt(4.0*pow(M_PI,3.0)*pow(psd,2)/deltat/pow(deltax,2));
+      stddev = sqrt(4.0*pow(M_PI,3.0)*pow(asd,2)/deltat/pow(deltax,2));
     }
     if(configf.optional("Ranseed", seed)) {
       random = new Random(seed, mean, stddev);

--- a/src/timeseries.cpp
+++ b/src/timeseries.cpp
@@ -360,7 +360,7 @@ namespace TIMESERIES {
       // index of timeseries the same as that of population
       double deltax = atof(configf.find(
                              label("Population ",index+1)+"*Length").c_str()) /sqrt(nodes);
-      stddev = sqrt(4.0*pow(M_PI,3.0)*pow(asd,2)/deltat/pow(deltax,2));
+      stddev = sqrt(2.0*4.0*pow(M_PI,3.0)*pow(asd,2)/deltat/pow(deltax,2));
     }
     if(configf.optional("Ranseed", seed)) {
       random = new Random(seed, mean, stddev);

--- a/src/timeseries.h
+++ b/src/timeseries.h
@@ -97,7 +97,7 @@ namespace TIMESERIES {
   struct White : public Timeseries {
     uint_fast64_t seed = 0; ///<
     double stddev = 0.0;    ///<
-    double psd = 0.0;       ///<
+    double asd = 0.0;       ///<
     double mean = 0.0;      ///<
     double deltax = 0.0;    ///<
     Random* random;
@@ -112,7 +112,7 @@ namespace TIMESERIES {
   struct WhiteCoherent : public Timeseries {
     uint_fast64_t seed = 0; ///<
     double stddev = 0.0;      ///<
-    double psd    = 0.0;      ///<
+    double asd    = 0.0;      ///<
     double mean   = 0.0;      ///<
     Random* random;
     WhiteCoherent(size_type nodes, double deltat, size_type index) : Timeseries(nodes, deltat, index) {}

--- a/test/numerical/eirs-coupling-ramp.conf
+++ b/test/numerical/eirs-coupling-ramp.conf
@@ -64,7 +64,7 @@ Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340.0
 
 Population 5: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0 Mean: 1.0 PSD: 1.0e-05
+ Stimulus: White - Onset: 0 Mean: 1.0 ASD: 1.0e-05
 
 Propagator 1: Wave - Tau: 0.0 Range: 0.086 gamma: 116.0
 Propagator 2:  Map - Tau: 0.0

--- a/test/numerical/eirs-dendrite-integral.conf
+++ b/test/numerical/eirs-dendrite-integral.conf
@@ -56,7 +56,7 @@ Firing: Function: Sigmoid Theta: 0.01292 Sigma: 0.0038 Qmax: 340.0
 
 Population 5: Stimulation
 Length: 0.5
- Stimulus: White - Onset: 0.0 Mean: 1.0 PSD: 1.0e-05
+ Stimulus: White - Onset: 0.0 Mean: 1.0 ASD: 1.0e-05
 
 Propagator 1: Wave - Tau: 0.0 Range: 0.086 gamma: 116.0
 Propagator 2:  Map - Tau: 0.0

--- a/test/numerical/eirs-eyes-closed.conf
+++ b/test/numerical/eirs-eyes-closed.conf
@@ -55,7 +55,7 @@ Population 4: Relay
 
 Population 5: Stimulation
  Length: 0.5
- Stimulus: White - Onset: 0.0 Mean: 1.0 PSD: 0.0001
+ Stimulus: White - Onset: 0.0 Mean: 1.0 ASD: 0.0001
 
 Propagator 1: Wave -             Range: 0.086 gamma: 116.0
 Propagator 2:  Map -

--- a/test/numerical/eirs-spindles.conf
+++ b/test/numerical/eirs-spindles.conf
@@ -55,7 +55,7 @@ Population 4: Relay
 
 Population 5: Stimulation
  Length: 0.5
- Stimulus: White - Onset: 0.0 Mean: 1.0 PSD: 0.0003
+ Stimulus: White - Onset: 0.0 Mean: 1.0 ASD: 0.0003
 
 Propagator 1: Wave -             Range: 0.086 gamma: 116.0
 Propagator 2:  Map -

--- a/test/numerical/stimulus-white-no-grid.conf
+++ b/test/numerical/stimulus-white-no-grid.conf
@@ -12,7 +12,7 @@ To 1:  0
 
 Population 1: Stimulation
 Length: 0.5
-    Stimulus: White - Onset: 0 Mean: 0 PSD: 1e-05
+    Stimulus: White - Onset: 0 Mean: 0 ASD: 1e-05
 
 Output: Node: All Start: 0
 Population: 1

--- a/test/numerical/stimulus-white-rectangular-grid.conf
+++ b/test/numerical/stimulus-white-rectangular-grid.conf
@@ -13,7 +13,7 @@ To 1:  0
 
 Population 1: Stimulation
 Length: 0.5
-    Stimulus: White - Onset: 0 Mean: 0 PSD: 1e-05
+    Stimulus: White - Onset: 0 Mean: 0 ASD: 1e-05
 
 Output: Node: All Start: 0
 Population: 1

--- a/test/numerical/stimulus-white-square-grid.conf
+++ b/test/numerical/stimulus-white-square-grid.conf
@@ -13,7 +13,7 @@ To 1:  0
 
 Population 1: Stimulation
 Length: 0.5
-    Stimulus: White - Onset: 0 Mean: 0 PSD: 1e-05
+    Stimulus: White - Onset: 0 Mean: 0 ASD: 1e-05
 
 Output: Node: All Start: 0
 Population: 1


### PR DESCRIPTION
This PR updates the parameter name formerly known as PSD, because it is in fact and amplitude density (in of [units of phi / sqrt[(rad/s)] ] and not a power density in  [ square units of phi / (rad/s)]. 

It also generalizes rfft to yield the double-sided spectrum. 